### PR TITLE
Removed `snprintf()` to support the Arduino 101

### DIFF
--- a/src/Media.h
+++ b/src/Media.h
@@ -31,38 +31,40 @@
 #include "ShieldEvent.h"
 #include "VirtualShield.h"
 
-class Media : public Sensor
-{
-public:
-	Media(const VirtualShield &shield);
+class Media : public Sensor {
+  public:
+    Media(const VirtualShield &shield);
 
-	int play(const char * url, long length = 0);
-	int play(const String &url, long length = 0);
+    int play(const char * url, long length = 0);
+    int play(const String &url, long length = 0);
 
-	inline int playVideo(const char * url, long length = 0) {
+    inline int playVideo(const char * url, long length = 0) {
         const long full_length = length + 7;
         char *full_url = new char[full_length];
         int return_value = 0;
 
-        snprintf(full_url, full_length, "VIDEOS:%s", url);
-		return_value = play(full_url, full_length);
+        //snprintf(full_url, full_length, "VIDEOS:%s", url);
+        strncpy(full_url, "VIDEOS:", 7);
+        strncpy(full_url + 7, url, length);
+
+        return_value = play(full_url, full_length);
         delete[] full_url;
         return return_value;
-	}
+    }
 
-	inline int playVideo(const String &url, long length = 0) {
-		return playVideo(url.c_str(), length);
-	}
+    inline int playVideo(const String &url, long length = 0) {
+        return playVideo(url.c_str(), length);
+    }
 
-	inline int playAudio(const char * url, long length = 0) {
-		return playVideo(url, length);
-	}
+    inline int playAudio(const char * url, long length = 0) {
+        return playVideo(url, length);
+    }
 
-	inline int playAudio(const String &url, long length = 0) {
-		return playVideo(url.c_str(), length);
-	}
+    inline int playAudio(const String &url, long length = 0) {
+        return playVideo(url.c_str(), length);
+    }
 
-	void onJsonReceived(JsonObject& root, ShieldEvent* shieldEvent) override;
+    void onJsonReceived(JsonObject& root, ShieldEvent* shieldEvent) override;
 };
 
 #endif

--- a/src/Recognition.cpp
+++ b/src/Recognition.cpp
@@ -127,9 +127,31 @@ bool Recognition::heard(int spokenNumber) {
     const int length = this->length[0];
     char * buffer = new char[length];
     bool return_value = false;
-
-    snprintf(buffer, length, "%d", spokenNumber);
-	return_value = heard(buffer);
+    int i = 0, val = spokenNumber;
+    
+    //snprintf(buffer, length, "%d", spokenNumber);
+    if ( length >= 1 ) { buffer[length - 1] = '\n'; }
+    if ( length >= 2 ) {
+        i = (length - 2);
+        if ( 0 == val ) {
+            buffer[i] = '0';
+        } else {
+            // Map each digit to the corresponding alpha character (from right to left)
+            for (; (i >= 0) ; --i, val /= 10) {
+                buffer[i] = "0123456789abcdef"[val % 10];
+            }
+            // Add the minus sign if negative
+            if ( spokenNumber < 0 && i >= 0) { buffer[i] = '-'; }
+        }
+        // Left justify the string
+        if ( i > 0 ) {
+            for (int j = 0 ; i < length; ++i, ++j) {
+                buffer[j] = buffer[i];
+            }
+        }
+    }
+    
+    return_value = heard(buffer);
     delete[] buffer;
     return return_value;
 }

--- a/src/VirtualShield.cpp
+++ b/src/VirtualShield.cpp
@@ -841,6 +841,10 @@ int VirtualShield::sendFlashStringOnSerial(const char* flashStringAdr, int start
 	for (size_t i = actualStart; i < strlen(flashStringAdr); i++)
 	{
 		dataChar = *(flashStringAdr + i);
+#elif defined(_VARIANT_ARDUINO_101_X_)
+	for (size_t i = actualStart; i < strlen_P(flashStringAdr); i++)
+	{
+		dataChar = pgm_read_byte_near(flashStringAdr + i);
 #else
 	for (size_t i = actualStart; i < strlen_PF((uint_farptr_t)flashStringAdr); i++)
 	{


### PR DESCRIPTION
`snprintf()` is not supported by the Intel arc-elf compiler
